### PR TITLE
Missing translations and escape

### DIFF
--- a/views/index.php
+++ b/views/index.php
@@ -17,8 +17,8 @@
             <tr>
               <td style="font-style: italic; border-bottom: 1px solid grey"><?php echo esc($key); ?></td>
               <?php foreach ($languages as $lang): ?>
-                <?php $value = $strings[$lang]; ?>
-                <td><input style="width: 100%" type="text" name="<?php echo esc("trans__${lang}__${key}"); ?>" value="<?php echo html($value) ?>"></td>
+                <?php $value = $strings[$lang]; $value = str_replace("\"", "&#34;", $value); ?>
+                <td><input style="width: 100%" type="text" name="<?php echo esc("trans__${lang}__${key}"); ?>" value="<?php echo $value ?>"></td>
               <?php endforeach ?>
             </tr>
           <?php endforeach ?>

--- a/views/index.php
+++ b/views/index.php
@@ -15,10 +15,10 @@
           </tr>
           <?php foreach ($translations as $key => $strings): ?>
             <tr>
-              <td style="font-style: italic; border-bottom: 1px solid grey"><?php echo $key; ?></td>
+              <td style="font-style: italic; border-bottom: 1px solid grey"><?php echo esc($key); ?></td>
               <?php foreach ($languages as $lang): ?>
                 <?php $value = $strings[$lang]; ?>
-                <td><input style="width: 100%" type="text" name="<?php echo "trans__${lang}__${key}"; ?>" value="<?php echo html($value) ?>"></td>
+                <td><input style="width: 100%" type="text" name="<?php echo esc("trans__${lang}__${key}"); ?>" value="<?php echo html($value) ?>"></td>
               <?php endforeach ?>
             </tr>
           <?php endforeach ?>

--- a/views/index.php
+++ b/views/index.php
@@ -16,7 +16,8 @@
           <?php foreach ($translations as $key => $strings): ?>
             <tr>
               <td style="font-style: italic; border-bottom: 1px solid grey"><?php echo $key; ?></td>
-              <?php foreach ($strings as $lang => $value): ?>
+              <?php foreach ($languages as $lang): ?>
+                <?php $value = $strings[$lang]; ?>
                 <td><input style="width: 100%" type="text" name="<?php echo "trans__${lang}__${key}"; ?>" value="<?php echo html($value) ?>"></td>
               <?php endforeach ?>
             </tr>


### PR DESCRIPTION
This PR fixes the following issues:

*   If a translation key is missing in some language, no input box was displayed. Now, an empty inut field is displayed in such cases
*   If the key contains html code, it would have been interpreted by the browser and not displayed correctly. Now, it will be escaped.
*   If the value contained quotes, the generated html for the input field is broken - the quotes need to be escaped so that the value is fully displayed inside the input field. Note: Only the quotes are escaped, nothing else - so it's still possible to have some html code for the values.
