### PR TITLE
Escape only single quotes ("'") and backslashes ("\")

### DIFF
--- a/static-translations.php
+++ b/static-translations.php
@@ -64,7 +64,7 @@ if(class_exists('Panel')) {
 				$lang = $splode[1];
 				$key = $splode[2];
 
-				$translations[$lang][] = 'l::set(\'' . addslashes($key) . '\', \'' . addslashes($pair['value']) . '\');';
+				$translations[$lang][] = 'l::set(\'' . addcslashes($key, '\\\'') . '\', \'' . addcslashes($pair['value'], '\\\'') . '\');';
 			}
 
 			foreach ($translations as $lang => $codelines) {


### PR DESCRIPTION
and leave all other characters untouched.

We are using single quote strings, when we re-generate the language files. So, no other characters need to be escaped.

The old code with `addslashes` escaped also double-quotes. If you have a language value that is e.g.

    l::set('terms', 'Accept our <a href="/terms">terms</a>');

After saving with static-translations, this was transformed into

    l::set('terms', 'Accept our <a href=\"/terms\">terms</a>');

and the link was broken...

With this fix, all my current language values are not changed when I re-save them with static-translations.