### PR TITLE
Send the translations as a single jsondata variable

### DIFF
--- a/static-translations.php
+++ b/static-translations.php
@@ -50,30 +50,21 @@ if(class_exists('Panel')) {
 		public function setTranslations() {
 			$languagesRoot = panel()->site()->kirby()->roots()->languages() . DS;
 
-			$post = file_get_contents('php://input');
-			$post = array_map(function($item) {
-				
-				$splode = array_map('urldecode', explode('=', $item));
+			$post = r::data("jsondata");
+			$post = json_decode($post, true);
 
-				return [
-					'key' => $splode[0],
-					'value' => $splode[1]
-				];
+			$submitted = array_filter($post, function($key) {
+				return strpos($key, 'trans__') === 0;
+			}, ARRAY_FILTER_USE_KEY);
 
-			}, explode('&', $post));
-
-			$submitted = array_filter($post, function($pair) {
-				return strpos($pair['key'], 'trans__') === 0;
-			});
-			
 			$translations = array();
 
-			foreach ($submitted as $pair) {
-				$splode = explode('__', $pair['key'], 3);
+			foreach ($submitted as $key => $value) {
+				$splode = explode('__', $key, 3);
 				$lang = $splode[1];
 				$key = $splode[2];
 
-				$translations[$lang][] = 'l::set(\'' . addcslashes($key, '\\\'') . '\', \'' . addcslashes($pair['value'], '\\\'') . '\');';
+				$translations[$lang][] = 'l::set(\'' . addcslashes($key, '\\\'') . '\', \'' . addcslashes($value, '\\\'') . '\');';
 			}
 
 			foreach ($translations as $lang => $codelines) {

--- a/views/index.php
+++ b/views/index.php
@@ -6,7 +6,7 @@
       <h2 class="hgroup hgroup-single-line hgroup-compressed cf"><span class="hgroup-title">Translations</span></h2>
 
 
-      <form method="POST" action="<?php echo panel()->urls()->index . '/translations' ?>" class="form">
+      <form id="form-static-translation">
         <table style="width: 100%">
           <tr>
             <th>Key</th>
@@ -30,7 +30,38 @@
           <input class="btn btn-rounded btn-submit" type="submit" value="<?php echo l::get('save'); ?>">
         </fieldset>
       </form>
+
+      <form method="POST" action="<?php echo panel()->urls()->index . '/translations' ?>" id="form-static-translation-json">
+          <input type="hidden" name="csrf" value="<?php echo panel()->csrf() ?>">
+          <input type="hidden" name="jsondata" value="">
+      </form>
+
     </div>
   </div>
 
 </div>
+
+<script type="text/javascript">
+// https://stackoverflow.com/questions/1255948/post-data-in-json-format
+(function() {
+    var form = document.getElementById("form-static-translation");
+    var jsonform = document.getElementById("form-static-translation-json");
+
+    form.onsubmit = function(e) {
+        // stop the regular form submission
+        e.preventDefault();
+
+        // collect the form data while iterating over the inputs
+        var data = {};
+        for (var i = 0, ii = form.length; i < ii; ++i) {
+          var input = form[i];
+          if (input.name) {
+            data[input.name] = input.value;
+          }
+        }
+
+        jsonform["jsondata"].value = JSON.stringify(data);
+        jsonform.submit();
+      };
+})();
+</script>


### PR DESCRIPTION
 instead of multiple post vars.

If you have many, many translation strings (or languages), then you'll hit the
default limit of max post vars.